### PR TITLE
Support big sur

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Therefore, I have created a script to force the User Consent item to be allowed.
 ## Requirements
 
 * Full disk access
-   * This script reads TCC database
+  * This script reads TCC database
 * macOS 10.14 Mojave or later
 
 ## How to use
@@ -75,18 +75,26 @@ If you want to specify more than one, you can use comma-separated values like:
 * AddressBook
 * All
 * AppleEvents
+* BluetoothAlways
+* BluetoothPeripheral
+* BluetoothWhileInUse
 * Calendar
+* Calls
 * Camera
 * ContactsFull
 * ContactsLimited
 * DeveloperTool
+* FaceID
 * Facebook
 * FileProviderDomain
 * FileProviderPresence
+* KeyboardNetwork
 * LinkedIn
 * ListenEvent
 * Liverpool
 * Location
+  * Gone by 11.0
+* MSO
 * MediaLibrary
 * Microphone
 * Motion
@@ -95,6 +103,28 @@ If you want to specify more than one, you can use comma-separated values like:
 * PostEvent
 * Reminders
 * ScreenCapture
+* SensorKitAmbientLightSensor
+* SensorKitDeviceUsage
+* SensorKitElevation
+* SensorKitForegroundAppCategory
+* SensorKitKeyboardMetrics
+* SensorKitLocationMetrics
+* SensorKitMessageUsage
+* SensorKitMotion
+* SensorKitMotionHeartRate
+* SensorKitOdometer
+* SensorKitPedometer
+* SensorKitPhoneUsage
+* SensorKitSpeechMetrics
+* SensorKitStrideCalibration
+* SensorKitWatchAmbientLightSensor
+* SensorKitWatchFallStats
+* SensorKitWatchForegroundAppCategory
+* SensorKitWatchHeartRate
+* SensorKitWatchMotion
+* SensorKitWatchOnWristState
+* SensorKitWatchPedometer
+* SensorKitWatchSpeechMetrics
 * ShareKit
 * SinaWeibo
 * Siri

--- a/TCC-Permitter.sh
+++ b/TCC-Permitter.sh
@@ -76,7 +76,7 @@
 #     - Willow
 #######################################
 
-VERSION='0.2.1'
+VERSION='0.3.0'
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 # MARK: Functions

--- a/TCC-Permitter.sh
+++ b/TCC-Permitter.sh
@@ -9,18 +9,25 @@
 #     - AddressBook
 #     - All
 #     - AppleEvents
+#     - BluetoothAlways  # Introduced by 11.0
+#     - BluetoothPeripheral  # Introduced by 11.0
+#     - BluetoothWhileInUse  # Introduced by 11.0
 #     - Calendar
+#     - Calls  # Introduced by 11.0
 #     - Camera
 #     - ContactsFull
 #     - ContactsLimited
 #     - DeveloperTool
+#     - FaceID  # Introduced by 11.0
 #     - Facebook
 #     - FileProviderDomain
 #     - FileProviderPresence
+#     - KeyboardNetwork  # Introduced by 11.0
 #     - LinkedIn
 #     - ListenEvent
 #     - Liverpool
-#     - Location
+#     - Location  # Gone from 11.0
+#     - MSO  # Introduced by 11.0
 #     - MediaLibrary
 #     - Microphone
 #     - Motion
@@ -29,6 +36,28 @@
 #     - PostEvent
 #     - Reminders
 #     - ScreenCapture
+#     - SensorKitAmbientLightSensor  # Introduced by 11.0
+#     - SensorKitDeviceUsage  # Introduced by 11.0
+#     - SensorKitElevation  # Introduced by 11.0
+#     - SensorKitForegroundAppCategory  # Introduced by 11.0
+#     - SensorKitKeyboardMetrics  # Introduced by 11.0
+#     - SensorKitLocationMetrics  # Introduced by 11.0
+#     - SensorKitMessageUsage  # Introduced by 11.0
+#     - SensorKitMotion  # Introduced by 11.0
+#     - SensorKitMotionHeartRate  # Introduced by 11.0
+#     - SensorKitOdometer  # Introduced by 11.0
+#     - SensorKitPedometer  # Introduced by 11.0
+#     - SensorKitPhoneUsage  # Introduced by 11.0
+#     - SensorKitSpeechMetrics  # Introduced by 11.0
+#     - SensorKitStrideCalibration  # Introduced by 11.0
+#     - SensorKitWatchAmbientLightSensor  # Introduced by 11.0
+#     - SensorKitWatchFallStats  # Introduced by 11.0
+#     - SensorKitWatchForegroundAppCategory  # Introduced by 11.0
+#     - SensorKitWatchHeartRate  # Introduced by 11.0
+#     - SensorKitWatchMotion  # Introduced by 11.0
+#     - SensorKitWatchOnWristState  # Introduced by 11.0
+#     - SensorKitWatchPedometer  # Introduced by 11.0
+#     - SensorKitWatchSpeechMetrics  # Introduced by 11.0
 #     - ShareKit
 #     - SinaWeibo
 #     - Siri
@@ -68,7 +97,7 @@ run_as_user() {
 #######################################
 # Output info log with timestamp.
 # Arguments:
-#   $@: Script to run
+#   $1: text to print
 # Outputs:
 #   Writes a argument with timestamp to stdout
 #######################################
@@ -82,7 +111,7 @@ print_info_log(){
 #######################################
 # Output error log with timestamp.
 # Arguments:
-#   $@: Script to run
+#   $1: text to print
 # Outputs:
 #   Writes a argument with timestamp to stdout
 #######################################
@@ -93,19 +122,85 @@ print_error_log(){
   echo "$timestamp [ERROR] $1"
 }
 
-#######################################
-# Get TCC service list.
-# Arguments:
-#   None
-# Outputs:
-#   Writes TCC servcies list to stdout
-#######################################
-get_ttc_services(){
-  strings /System/Library/PrivateFrameworks/TCC.framework/TCC | grep kTCCService | grep -v '%'
-}
-
 # MARK: Main script
 
+# This list was obtained with the following command
+#
+# 11.0 and later:
+#   otool -V -s __TEXT __cstring /System/Library/PrivateFrameworks/TCC.framework/Versions/A/Resources/tccd | awk '{ print $2 }' | grep -E '^kTCCService.+' | sort | uniq
+# 10.15 and older:
+#   otool -V -s __TEXT __cstring /System/Library/PrivateFrameworks/TCC.framework/Versions/Current/TCC |awk '{ print $2 }' | grep -E '^kTCCService.+' | sort | uniq
+TCC_SERVICE_NAME_LIST=(
+"kTCCServiceAccessibility"
+"kTCCServiceAddressBook"
+"kTCCServiceAll"
+"kTCCServiceAppleEvents"
+"kTCCServiceBluetoothAlways"
+"kTCCServiceBluetoothPeripheral"
+"kTCCServiceBluetoothWhileInUse"
+"kTCCServiceCalendar"
+"kTCCServiceCalls"
+"kTCCServiceCamera"
+"kTCCServiceContactsFull"
+"kTCCServiceContactsLimited"
+"kTCCServiceDeveloperTool"
+"kTCCServiceFaceID"
+"kTCCServiceFacebook"
+"kTCCServiceFileProviderDomain"
+"kTCCServiceFileProviderPresence"
+"kTCCServiceKeyboardNetwork"
+"kTCCServiceLinkedIn"
+"kTCCServiceListenEvent"
+"kTCCServiceLiverpool"
+"kTCCServiceLocation"
+"kTCCServiceMSO"
+"kTCCServiceMediaLibrary"
+"kTCCServiceMicrophone"
+"kTCCServiceMotion"
+"kTCCServicePhotos"
+"kTCCServicePhotosAdd"
+"kTCCServicePostEvent"
+"kTCCServiceReminders"
+"kTCCServiceScreenCapture"
+"kTCCServiceSensorKitAmbientLightSensor"
+"kTCCServiceSensorKitDeviceUsage"
+"kTCCServiceSensorKitElevation"
+"kTCCServiceSensorKitForegroundAppCategory"
+"kTCCServiceSensorKitKeyboardMetrics"
+"kTCCServiceSensorKitLocationMetrics"
+"kTCCServiceSensorKitMessageUsage"
+"kTCCServiceSensorKitMotion"
+"kTCCServiceSensorKitMotionHeartRate"
+"kTCCServiceSensorKitOdometer"
+"kTCCServiceSensorKitPedometer"
+"kTCCServiceSensorKitPhoneUsage"
+"kTCCServiceSensorKitSpeechMetrics"
+"kTCCServiceSensorKitStrideCalibration"
+"kTCCServiceSensorKitWatchAmbientLightSensor"
+"kTCCServiceSensorKitWatchFallStats"
+"kTCCServiceSensorKitWatchForegroundAppCategory"
+"kTCCServiceSensorKitWatchHeartRate"
+"kTCCServiceSensorKitWatchMotion"
+"kTCCServiceSensorKitWatchOnWristState"
+"kTCCServiceSensorKitWatchPedometer"
+"kTCCServiceSensorKitWatchSpeechMetrics"
+"kTCCServiceShareKit"
+"kTCCServiceSinaWeibo"
+"kTCCServiceSiri"
+"kTCCServiceSpeechRecognition"
+"kTCCServiceSystemPolicyAllFiles"
+"kTCCServiceSystemPolicyDesktopFolder"
+"kTCCServiceSystemPolicyDeveloperFiles"
+"kTCCServiceSystemPolicyDocumentsFolder"
+"kTCCServiceSystemPolicyDownloadsFolder"
+"kTCCServiceSystemPolicyNetworkVolumes"
+"kTCCServiceSystemPolicyRemovableVolumes"
+"kTCCServiceSystemPolicySysAdminFiles"
+"kTCCServiceTencentWeibo"
+"kTCCServiceTwitter"
+"kTCCServiceUbiquity"
+"kTCCServiceWillow"
+)
 autoload is-at-least
 
 if ! is-at-least 10.14 "$(sw_vers -productVersion)";then
@@ -135,14 +230,20 @@ if [[ ! "${2}" ]];then
   print_error_log "You need to set service name as second argument."
   exit 1
 fi
-TCC_SERVICE_NAME_LIST=($(echo "${2}" | tr ',' ' '))
+ALLOWING_TCC_SERVICE_SHORT_NAME_LIST=($(echo "${2}" | tr ',' ' '))
 
-for TCC_SERVICE_NAME in "${TCC_SERVICE_NAME_LIST[@]}";do
-  if ! get_ttc_services | sed -e 's/kTCCService//' | sort | grep -qE "^${TCC_SERVICE_NAME}$";then
-    print_error_log "${TCC_SERVICE_NAME} is invalid name as TCC Service."
-    exit 1
+INVALID_TCC_SERVICE_SHORT_NAME_LIST=()
+for ALLOWING_TCC_SERVICE_SHORT_NAME in "${ALLOWING_TCC_SERVICE_SHORT_NAME_LIST[@]}";do
+  ALLOWING_TCC_SERVICE_NAME="kTCCService${ALLOWING_TCC_SERVICE_SHORT_NAME}"
+  if ! (($TCC_SERVICE_NAME_LIST[(Ie)${ALLOWING_TCC_SERVICE_NAME}]));then
+    INVALID_TCC_SERVICE_SHORT_NAME_LIST+=("${ALLOWING_TCC_SERVICE_SHORT_NAME}")
   fi
 done
+
+if [[ "${#INVALID_TCC_SERVICE_SHORT_NAME_LIST[@]}" -ne 0 ]];then
+  print_error_log "${(j:, :)INVALID_TCC_SERVICE_SHORT_NAME_LIST} are invalid name as TCC Service."
+  exit 1
+fi
 
 print_info_log "Start TCC-Permitter..."
 
@@ -155,23 +256,33 @@ if [[ ! -e "${TCC_DB_PATH}" ]];then
   exit 1
 fi
 
-for TCC_SERVICE_NAME in "${TCC_SERVICE_NAME_LIST[@]}";do
-  print_info_log "Granting ${TCC_SERVICE_NAME}..."
+ACCESS_SCHEMA=$(run_as_user sqlite3 "${TCC_DB_PATH}" ".schema access")
+HAS_AUTH_VALUE_COLUMN=$(echo "${ACCESS_SCHEMA}" | (grep auth_value || true))
+if [[ "${HAS_AUTH_VALUE_COLUMN}" ]];then
+  DENIED_SQL_CONDITION="auth_value = '0'"
+  ALLOWED_SQL_CONDITION="auth_value = '2'"
+else
+  DENIED_SQL_CONDITION="allowed = '0'"
+  ALLOWED_SQL_CONDITION="allowed = '1'"
+fi
 
-  TCC_NOT_ALLOWED_ACCESS_PRESENT=$(run_as_user sqlite3 "${TCC_DB_PATH}" "SELECT service FROM access WHERE allowed = '0' AND client = '${BUNDLE_ID_OR_BINARY_PATH}' AND service = 'kTCCService${TCC_SERVICE_NAME}'")
+for ALLOWING_TCC_SERVICE_SHORT_NAME in "${ALLOWING_TCC_SERVICE_SHORT_NAME_LIST[@]}";do
+  print_info_log "Granting ${ALLOWING_TCC_SERVICE_SHORT_NAME}..."
+
+  TCC_NOT_ALLOWED_ACCESS_PRESENT=$(run_as_user sqlite3 "${TCC_DB_PATH}" "SELECT service FROM access WHERE ${DENIED_SQL_CONDITION} AND client = '${BUNDLE_ID_OR_BINARY_PATH}' AND service = 'kTCCService${ALLOWING_TCC_SERVICE_SHORT_NAME}'")
 
   if [[ ! "${TCC_NOT_ALLOWED_ACCESS_PRESENT}" ]];then
-    TCC_ALLOWED_ACCESS_PRESENT=$(run_as_user sqlite3 "${TCC_DB_PATH}" "SELECT service FROM access WHERE allowed = '1' AND client = '${BUNDLE_ID_OR_BINARY_PATH}' AND service = 'kTCCService${TCC_SERVICE_NAME}'")
+    TCC_ALLOWED_ACCESS_PRESENT=$(run_as_user sqlite3 "${TCC_DB_PATH}" "SELECT service FROM access WHERE ${ALLOWED_SQL_CONDITION} AND client = '${BUNDLE_ID_OR_BINARY_PATH}' AND service = 'kTCCService${ALLOWING_TCC_SERVICE_SHORT_NAME}'")
 
     if [[ "${TCC_ALLOWED_ACCESS_PRESENT}" ]];then
-      print_info_log "${TCC_SERVICE_NAME} of ${BUNDLE_ID_OR_BINARY_PATH} is already allowed."
+      print_info_log "${ALLOWING_TCC_SERVICE_SHORT_NAME} of ${BUNDLE_ID_OR_BINARY_PATH} is already allowed."
     else
       print_info_log "There does not seem to be a single prompt for TCC access rights yet."
     fi
   else
-    run_as_user sqlite3 "${TCC_DB_PATH}" "UPDATE access SET allowed = '1', last_modified = '$(date +%s)' WHERE allowed = '0' AND client = '${BUNDLE_ID_OR_BINARY_PATH}' AND service = 'kTCCService${TCC_SERVICE_NAME}'"
+    run_as_user sqlite3 "${TCC_DB_PATH}" "UPDATE access SET ${ALLOWED_SQL_CONDITION}, last_modified = '$(date +%s)' WHERE ${DENIED_SQL_CONDITION} AND client = '${BUNDLE_ID_OR_BINARY_PATH}' AND service = 'kTCCService${ALLOWING_TCC_SERVICE_SHORT_NAME}'"
 
-    print_info_log "Successfully allowed for ${TCC_SERVICE_NAME} TCC service of ${BUNDLE_ID_OR_BINARY_PATH}."
+    print_info_log "Successfully allowed for ${ALLOWING_TCC_SERVICE_SHORT_NAME} TCC service of ${BUNDLE_ID_OR_BINARY_PATH}."
   fi
 done
 


### PR DESCRIPTION
## Background

* TCC database schema is changed from Big Sur.
    * The permission flag has been changed from `allowed` to `auth_value`.
* The binary path of the private framework has been changed.
    * The `strings` command is used for development purposes, so that wasn't good.

## Changes

* Added the ability to change SQL according to schema.
* The script itself now has a list of TCC service names.